### PR TITLE
Bugfix: replace some deprecated APIs for new version of Bazel

### DIFF
--- a/rules.bzl
+++ b/rules.bzl
@@ -2,11 +2,11 @@ load("//:aspects.bzl", "parameterized_info_aspect")
 
 def _java_info_impl(ctx):
     """Collect deps from our aspect."""
-    outputs = set()
+    outputs = depset()
 
     for dep in ctx.attr.deps:
         info = dep.info
-        outputs = outputs | info.transitive_jsons | info.transitive_protos
+        outputs = depset(transitive=[outputs, info.transitive_jsons, info.transitive_protos])
 
     return struct(
         files = outputs,


### PR DESCRIPTION
Some APIs no longer available with new version of bazel:
Use depset() instead of set()
Use depset(transitive=[]) instead of depset | depset 
Replace target.java with target[JavaInfo]
Since depset is no longer iterative, replace file.path for file in prop.compilation_classpath with file.path for file in prop.compilation_classpath.to_list()
Replace aspect_ctx.new_file with aspect_ctx.actions.declare_file since the old API is deprecated
Replace aspect_ctx.file_action with aspect_ctx.actions.write since the old API is deprecated